### PR TITLE
Allow a page to act as the navigation root

### DIFF
--- a/src/AlloyDemoKit/Controllers/DefaultPageController.cs
+++ b/src/AlloyDemoKit/Controllers/DefaultPageController.cs
@@ -4,6 +4,7 @@ using EPiServer;
 using EPiServer.Framework.DataAnnotations;
 using AlloyDemoKit.Models.Pages;
 using AlloyDemoKit.Models.ViewModels;
+using EPiServer.Web.Mvc;
 
 namespace AlloyDemoKit.Controllers
 {
@@ -21,6 +22,10 @@ namespace AlloyDemoKit.Controllers
     {
         public ViewResult Index(SitePageData currentPage)
         {
+            // Ensure there is a full referesh when the PageIsNavigationRoot is checked on the breadcrumb
+            var editHints = ViewData.GetEditHints<PageViewModel<SitePageData>, SitePageData>();
+            editHints.AddFullRefreshFor(m => m.PageIsNavigationRoot);
+
             var model = CreateModel(currentPage);
             return View(string.Format("~/Views/{0}/Index.cshtml", currentPage.GetOriginalType().Name), model);
         }

--- a/src/AlloyDemoKit/Views/Shared/Breadcrumbs.cshtml
+++ b/src/AlloyDemoKit/Views/Shared/Breadcrumbs.cshtml
@@ -1,31 +1,33 @@
+@model IPageViewModel<SitePageData>
+
 @using EPiServer.Core
 @using EPiServer.Web
 @*Helper used as template for a page in the bread crumb, recursively triggering the rendering of the next page*@
-@helper ItemTemplate(HtmlHelpers.MenuItem breadCrumbItem) {
-    if (breadCrumbItem.Selected)
+@helper ItemTemplate(HtmlHelpers.MenuItem breadCrumbItem)
+{
+if (breadCrumbItem.Selected)
+{
+    if (breadCrumbItem.Page.HasTemplate() && !breadCrumbItem.Page.ContentLink.CompareToIgnoreWorkID(Model.CurrentPage.ContentLink))
     {
-        if (breadCrumbItem.Page.HasTemplate() && !breadCrumbItem.Page.ContentLink.CompareToIgnoreWorkID(Model.CurrentPage.ContentLink))
-        {
             @Html.PageLink(breadCrumbItem.Page)
-        }
-        else
-        {
+    }
+    else
+    {
             @breadCrumbItem.Page.PageName
-        }
-        if (!breadCrumbItem.Page.ContentLink.CompareToIgnoreWorkID(Model.CurrentPage.ContentLink))
-        {
+    }
+    if (!breadCrumbItem.Page.ContentLink.CompareToIgnoreWorkID(Model.CurrentPage.ContentLink))
+    {
             <span class="divider">/</span>
             @Html.MenuList(breadCrumbItem.Page.ContentLink, ItemTemplate)
-        }
     }
 }
-
-<div class="row hideMyTracks">
+}
+<div class="row hideMyTracks"  @Html.EditAttributes(m => m.CurrentPage.PageIsNavigationRoot)>
     <div class="span12">
         <ul class="alloyBreadcrumb">
-            @Html.ContentLink(SiteDefinition.Current.StartPage)
+            @Html.ContentLink(Model.CurrentPage.NavigationRoot)
             <span class="divider">/</span>
-            @Html.MenuList(SiteDefinition.Current.StartPage, ItemTemplate, requireVisibleInMenu: false, requirePageTemplate: false) 
+            @Html.MenuList(Model.CurrentPage.NavigationRoot, ItemTemplate, requireVisibleInMenu: false, requirePageTemplate: false)
         </ul>
     </div>
-</div> 
+</div>

--- a/src/AlloyDemoKit/Views/Shared/Header.cshtml
+++ b/src/AlloyDemoKit/Views/Shared/Header.cshtml
@@ -23,10 +23,10 @@
                             <div class="nav-collapse">
                                 <ul class="nav">
                                     <li class="@(Model.CurrentPage.ContentLink.CompareToIgnoreWorkID(SiteDefinition.Current.StartPage) ? "active" : null)">@Html.ContentLink(SiteDefinition.Current.StartPage)</li>
-                                    @Html.MenuList(SiteDefinition.Current.StartPage, 
-                                                   @<li class="@(item.Selected ? "active" : null)">
-                                                        @Html.PageLink(item.Page, null, new { @class = string.Join(" ", item.Page.GetThemeCssClassNames())})
-                                                    </li>) 
+                                    @Html.MenuList(Model.CurrentPage.NavigationRoot,
+                                                @<li class="@(item.Selected ? "active" : null)">
+                                                    @Html.PageLink(item.Page, null, new { @class = string.Join(" ", item.Page.GetThemeCssClassNames()) })
+                                                </li>) 
                                 </ul>
                                 <div class="navbar-search pull-right">
                                     @{Html.RenderPartial("LanguageSelector", Model.CurrentPage);}


### PR DESCRIPTION
A new property called "Page is navigation root" is added to the settings
tab. When checked the page becomes the effective navigation root shows
as the start page of the bread crumb and also affects the left nav.
Useful for defining sets of pages as microsites. The breadcrumb can also
be clicked in on page edit to set and unset the flag.
