### PR TITLE
Fixed error in blog item creation of year/month pages...

### DIFF
--- a/src/AlloyDemoKit/Business/Blog/BlogTagInitialization.cs
+++ b/src/AlloyDemoKit/Business/Blog/BlogTagInitialization.cs
@@ -56,7 +56,7 @@ namespace AlloyDemoKit.Models.Pages.Business.Tags
 
                 if (parentPage is BlogStartPage)
                 {
-                    page.ParentLink = GetDatePageRef(page, startPublish, contentRepository);
+                    page.ParentLink = GetDatePageRef(parentPage, startPublish, contentRepository);
                 }
             }
         }


### PR DESCRIPTION
… where page to be created is passed instead of the parent