### PR TITLE
Bug/#205804

### DIFF
--- a/src/AlloyDemoKit/Business/PageViewContextFactory.cs
+++ b/src/AlloyDemoKit/Business/PageViewContextFactory.cs
@@ -52,7 +52,8 @@ namespace AlloyDemoKit.Business
                     LoginUrl = new MvcHtmlString(GetLoginUrl(currentContentLink)),
                     SearchPageRouteValues = requestContext.GetPageRoute(startPage.SearchPageLink),
                     SearchActionUrl = new MvcHtmlString(EPiServer.Web.Routing.UrlResolver.Current.GetUrl(startPage.SearchPageLink)),
-                    IsInReadonlyMode = _databaseMode.DatabaseMode == DatabaseMode.ReadOnly
+                    IsInReadonlyMode = _databaseMode.DatabaseMode == DatabaseMode.ReadOnly,
+                    ContactForm = startPage.ContactForm
                 };
         }
 

--- a/src/AlloyDemoKit/Models/Pages/StartPage.cs
+++ b/src/AlloyDemoKit/Models/Pages/StartPage.cs
@@ -4,6 +4,7 @@ using EPiServer.DataAbstraction;
 using EPiServer.DataAnnotations;
 using EPiServer.SpecializedProperties;
 using AlloyDemoKit.Models.Blocks;
+using EPiServer.Forms.Implementation.Elements;
 
 namespace AlloyDemoKit.Models.Pages
 {
@@ -64,6 +65,10 @@ namespace AlloyDemoKit.Models.Pages
 
         [Display(GroupName = Global.GroupNames.SiteSettings)]
         public virtual SiteLogotypeBlock SiteLogotype { get; set; }
+
+        [Display(GroupName = Global.GroupNames.SiteSettings)]
+        [AllowedTypes(typeof(FormContainerBlock))]
+        public virtual ContentArea ContactForm { get; set; }
 
     }
 }

--- a/src/AlloyDemoKit/Models/ViewModels/LayoutModel.cs
+++ b/src/AlloyDemoKit/Models/ViewModels/LayoutModel.cs
@@ -25,5 +25,6 @@ namespace AlloyDemoKit.Models.ViewModels
         public MvcHtmlString SearchActionUrl { get; set; }
 
         public bool IsInReadonlyMode {get;set;}
+        public ContentArea ContactForm { get; internal set; }
     }
 }

--- a/src/AlloyDemoKit/Views/Shared/Footer.cshtml
+++ b/src/AlloyDemoKit/Views/Shared/Footer.cshtml
@@ -34,6 +34,10 @@
                     </li>
                 </ul>
             </div>
+
+
+            @* Bug below *@
+            @Html.PropertyFor(Model.Layout.ContactForm)
         </div>
     </div>
 </div>


### PR DESCRIPTION
1. If you add a reference to epiform on the StartPage
2. and want to display it outside of the RenderBody()-method, then EPiForm will give errors in the console (and will not work the way it's intended).

You can follow my commits bellow